### PR TITLE
Add Recurring task

### DIFF
--- a/src/main/java/luke/Luke.java
+++ b/src/main/java/luke/Luke.java
@@ -50,14 +50,10 @@ public class Luke {
                 Command cmd = Parser.parse(inputs[0]);
                 assert(taskList != null);
                 cmd.execute(taskList);
-                if (Integer.parseInt(inputs[1].strip()) == 1) {
-                    taskList.get(i).markAsDone();
-                }
+                taskList.get(i).setDoneStatus(Integer.parseInt(inputs[1].strip()));
             }
-        } catch (FileNotFoundException e) {
-            System.err.println(e.getMessage());
-        } catch (NumberFormatException e) {
-            System.err.println(e.getMessage());
+        } catch (FileNotFoundException | IndexOutOfBoundsException | IllegalArgumentException e) {
+            e.getStackTrace();
         }
     }
 

--- a/src/main/java/luke/commands/CommandAction.java
+++ b/src/main/java/luke/commands/CommandAction.java
@@ -7,6 +7,7 @@ public enum CommandAction {
     DEADLINE(ActionType.ADD, "description,by"),
     TODO(ActionType.ADD, "description"),
     EVENT(ActionType.ADD, "description,at"),
+    RECUR(ActionType.ADD, "task,every,next"),
     MARK(ActionType.UPDATE, "index"),
     UNMARK(ActionType.UPDATE, "index"),
     DELETE(ActionType.UPDATE, "index"),

--- a/src/main/java/luke/commands/RecurCommand.java
+++ b/src/main/java/luke/commands/RecurCommand.java
@@ -1,0 +1,18 @@
+package luke.commands;
+
+import luke.data.tasks.RecurringTask;
+
+/**
+ * Implements the recur command.
+ */
+public class RecurCommand extends AddCommand {
+
+    /**
+     * Constructs the recur command with the specified recurring task.
+     *
+     * @param recurringTask The specified recurring task to be added.
+     */
+    public RecurCommand(RecurringTask recurringTask) {
+        super(recurringTask);
+    }
+}

--- a/src/main/java/luke/data/tasks/Deadline.java
+++ b/src/main/java/luke/data/tasks/Deadline.java
@@ -37,7 +37,7 @@ public class Deadline extends Task {
 
     @Override
     public String toString() {
-        return "[D]" + super.toString() + " (by: " + DateTimeParser.toString(this.date) + ")";
+        return "[D]" + super.toString() + "\n\t(by: " + DateTimeParser.toString(this.date) + ")";
     }
 
     @Override

--- a/src/main/java/luke/data/tasks/Event.java
+++ b/src/main/java/luke/data/tasks/Event.java
@@ -37,7 +37,7 @@ public class Event extends Task {
 
     @Override
     public String toString() {
-        return "[E]" + super.toString() + " (at: " + DateTimeParser.toString(this.date) + ")";
+        return "[E]" + super.toString() + "\n\t(at: " + DateTimeParser.toString(this.date) + ")";
     }
 
     @Override

--- a/src/main/java/luke/data/tasks/RecurDeadline.java
+++ b/src/main/java/luke/data/tasks/RecurDeadline.java
@@ -1,0 +1,59 @@
+package luke.data.tasks;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+
+import luke.parser.DateTimeParser;
+
+/**
+ * Implements a recurring deadline task.
+ */
+public class RecurDeadline extends RecurringTask {
+
+    protected LocalDateTime date;
+    /**
+     * Constructs a recurring deadline task with the specified description.
+     *
+     * @param description The specified description for the task.
+     * @param by          The datetime to indicate by when the task should be completed.
+     * @param every       The recurring duration.
+     * @param next        The next date to recur from.
+     * @throws DateTimeParseException If the datetime is not one of the format accepted by {@code DateTimeParser}
+     */
+    public RecurDeadline(String description, String by, String every, String next) throws DateTimeParseException {
+        super(description, every, next);
+        this.date = DateTimeParser.toLocalDateTime(by.stripTrailing());
+        updateDate();
+    }
+
+    /**
+     * Constructs a recurring deadline task with the argument map.
+     *
+     * @param args The map containing both the arguments required by Deadline class.
+     * @throws DateTimeParseException If the datetime is not one of the format accepted by {@code DateTimeParser}
+     */
+    public RecurDeadline(Map<String, String> args) throws DateTimeParseException {
+        this(args.get("description"), args.get("by"), args.get("every"), args.get("next"));
+    }
+
+    private void updateDate() {
+        LocalDateTime oldDate = date;
+        while (date.isBefore(LocalDateTime.now())) {
+            date = recurFunction.apply(date);
+        }
+        isNew = !oldDate.isEqual(date);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(super.toString(), "[D]", "\n\t(by: " + DateTimeParser.toString(this.date) + ")");
+    }
+
+    @Override
+    public String getCommandString() {
+        String baseFormat = super.getCommandString();
+        String taskFormat = String.format("deadline %s /by %s", description, DateTimeParser.toCommandString(this.date));
+        return String.format(baseFormat, taskFormat);
+    }
+}

--- a/src/main/java/luke/data/tasks/RecurEvent.java
+++ b/src/main/java/luke/data/tasks/RecurEvent.java
@@ -1,0 +1,60 @@
+package luke.data.tasks;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+
+import luke.parser.DateTimeParser;
+
+/**
+ * Implements a recurring event task.
+ */
+public class RecurEvent extends RecurringTask {
+
+    protected LocalDateTime date;
+
+    /**
+     * Constructs a recurring event task with the specified description.
+     *
+     * @param description The specified description for the task.
+     * @param at          The datetime to indicate at which time the event starts.
+     * @param every       The recurring duration.
+     * @param next        The next date to recur from.
+     * @throws DateTimeParseException If the datetime is not one of the format accepted by {@code DateTimeParser}
+     */
+    public RecurEvent(String description, String at, String every, String next) throws DateTimeParseException {
+        super(description, every, next);
+        this.date = DateTimeParser.toLocalDateTime(at.stripTrailing());
+        updateDate();
+    }
+
+    /**
+     * Constructs a recurring event task with the argument map.
+     *
+     * @param args The map containing both the arguments required by Event class.
+     * @throws DateTimeParseException If the datetime is not one of the format accepted by {@code DateTimeParser}
+     */
+    public RecurEvent(Map<String, String> args) throws DateTimeParseException {
+        this(args.get("description"), args.get("at"), args.get("every"), args.get("next"));
+    }
+
+    private void updateDate() {
+        LocalDateTime oldDate = date;
+        while (date.isBefore(LocalDateTime.now())) {
+            date = recurFunction.apply(date);
+        }
+        isNew = !oldDate.isEqual(date);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(super.toString(), "[E]", "\n\t(at: " + DateTimeParser.toString(this.date) + ")");
+    }
+
+    @Override
+    public String getCommandString() {
+        String baseFormat = super.getCommandString();
+        String taskFormat = String.format("event %s /at %s", description, DateTimeParser.toCommandString(this.date));
+        return String.format(baseFormat, taskFormat);
+    }
+}

--- a/src/main/java/luke/data/tasks/RecurTodo.java
+++ b/src/main/java/luke/data/tasks/RecurTodo.java
@@ -1,0 +1,41 @@
+package luke.data.tasks;
+
+import java.util.Map;
+
+/**
+ * Implements a recurring Todo task.
+ */
+public class RecurTodo extends RecurringTask {
+
+    /**
+     * Constructs a recurring todo task with the specified description.
+     *
+     * @param description The specified description for the task.
+     * @param every       The recurring duration.
+     * @param next        The next date to recur from.
+     */
+    public RecurTodo(String description, String every, String next) {
+        super(description, every, next);
+    }
+
+    /**
+     * Constructs a recurring todo task with the argument map.
+     *
+     * @param args The map containing the argument required by Todo class.
+     */
+    public RecurTodo(Map<String, String> args) {
+        this(args.get("description"), args.get("every"), args.get("next"));
+    }
+
+    @Override
+    public String toString() {
+        return String.format(super.toString(), "[T]", "");
+    }
+
+    @Override
+    public String getCommandString() {
+        String baseFormat = super.getCommandString();
+        String taskFormat = String.format("todo %s", description);
+        return String.format(baseFormat, taskFormat);
+    }
+}

--- a/src/main/java/luke/data/tasks/RecurringTask.java
+++ b/src/main/java/luke/data/tasks/RecurringTask.java
@@ -1,0 +1,66 @@
+package luke.data.tasks;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.function.Function;
+
+import luke.parser.DateTimeParser;
+
+/**
+ * Implements a Recurring task.
+ */
+public abstract class RecurringTask extends Task {
+
+    protected String every;
+    protected boolean isNew;
+    protected LocalDateTime recurDate;
+    protected Function<LocalDateTime, LocalDateTime> recurFunction;
+
+    /**
+     * Constructs a recurring task.
+     *
+     * @param every  The recurring duration.
+     * @param next   The next date to recur from.
+     * @throws DateTimeParseException If the every argument or datetime is not one of the
+     * format accepted by {@code DateTimeParser}
+     */
+    public RecurringTask(String description, String every, String next) throws DateTimeParseException {
+        super(description);
+        this.every = every.stripTrailing();
+        this.recurDate = DateTimeParser.toLocalDateTime(next.stripTrailing());
+        this.recurFunction = DateTimeParser.getDateTimeIncrementFunction(every.trim());
+        updateRecurDate();
+    }
+
+
+    private void updateRecurDate() {
+        LocalDateTime oldDate = recurDate;
+        while (recurDate.isBefore(LocalDateTime.now())) {
+            recurDate = recurFunction.apply(recurDate);
+        }
+        isNew = !oldDate.isEqual(recurDate);
+    }
+
+    protected String getDateAsCommandString() {
+        return DateTimeParser.toCommandString(recurDate);
+    }
+
+    @Override
+    public void setDoneStatus(int value) {
+        if (isNew) {
+            isNew = false;
+        } else {
+            super.setDoneStatus(value);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "[R]%s" + super.toString() + "%s (every: " + every + ")";
+    }
+
+    @Override
+    public String getCommandString() {
+        return "recur %s" + String.format(" /every %s /next %s", every, getDateAsCommandString());
+    }
+}

--- a/src/main/java/luke/data/tasks/Task.java
+++ b/src/main/java/luke/data/tasks/Task.java
@@ -9,7 +9,7 @@ public abstract class Task {
     protected boolean isFiltered;
 
     /**
-     * Construct a task with the specified description.
+     * Constructs a task with the specified description.
      * All task by default are set to not done.
      *
      * @param description The specified description for the task.
@@ -41,6 +41,13 @@ public abstract class Task {
      */
     public void markAsDone() {
         this.isDone = true;
+    }
+
+    /**
+     * Sets this task as done based on stored value in file.
+     */
+    public void setDoneStatus(int value) {
+        this.isDone = value == 1;
     }
 
     /**

--- a/src/main/java/luke/parser/DateTimeParser.java
+++ b/src/main/java/luke/parser/DateTimeParser.java
@@ -4,6 +4,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 /**
  * DateTime Parser with specific format.
@@ -12,10 +15,18 @@ import java.time.format.DateTimeParseException;
  */
 public class DateTimeParser {
 
+    private static final String ERROR_MESSAGE = "\"%s\" is not a valid argument for every.";
+    private static Map<String, Function<LocalDateTime, LocalDateTime>> recurFunctionMap = new HashMap<>() {{
+            put("day", dt -> dt.plusDays(1));
+            put("week", dt -> dt.plusWeeks(1));
+            put("month", dt -> dt.plusMonths(1));
+            put("year", dt -> dt.plusYears(1));
+        }};
+
     /**
      * Formatter containing all acceptable datetime format that user can pass as string.
      */
-    private static DateTimeFormatter fromStringToDate = new DateTimeFormatterBuilder()
+    private static DateTimeFormatter fromStringToDateTime = new DateTimeFormatterBuilder()
             .appendOptional(DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm"))
             .appendOptional(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"))
             .appendOptional(DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm"))
@@ -33,22 +44,29 @@ public class DateTimeParser {
     /**
      * Specific format [MMM dd yyyy HH:mm] to convert all date to string.
      */
-    private static DateTimeFormatter fromDateToString = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm");
+    private static DateTimeFormatter fromDateTimeToString = DateTimeFormatter.ofPattern("MMM dd yyyy HH:mm");
 
     /**
      * Specific format [dd/MM/yyyy HH:mm] to convert all date to command string.
      */
-    private static DateTimeFormatter fromDateToCommand = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
+    private static DateTimeFormatter fromDateTimeToCommand = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
 
+    public static Function<LocalDateTime, LocalDateTime> getDateTimeIncrementFunction(String every) {
+        if (!recurFunctionMap.containsKey(every)) {
+            throw new DateTimeParseException(String.format(ERROR_MESSAGE, every), every, 0);
+        }
+
+        return recurFunctionMap.get(every);
+    }
     public static LocalDateTime toLocalDateTime(String date) throws DateTimeParseException {
-        return LocalDateTime.parse(date, fromStringToDate);
+        return LocalDateTime.parse(date, fromStringToDateTime);
     }
 
     public static String toString(LocalDateTime date) {
-        return date.format(fromDateToString);
+        return date.format(fromDateTimeToString);
     }
 
     public static String toCommandString(LocalDateTime date) {
-        return date.format(fromDateToCommand);
+        return date.format(fromDateTimeToCommand);
     }
 }

--- a/src/test/java/luke/parser/ParserTest.java
+++ b/src/test/java/luke/parser/ParserTest.java
@@ -2,6 +2,9 @@ package luke.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.time.LocalDateTime;
+import java.util.function.Function;
+
 import org.junit.jupiter.api.Test;
 
 import luke.commands.Command;
@@ -22,11 +25,10 @@ class ParserTest {
                     String description = DESCRIPTIONS[i];
                     String datetime = String.format("%s %s", DATES[j], TIMES[k]);
                     String commandString = String.format("deadline %s /by %s", description, datetime);
-                    Command command = Parser.parse(commandString);
-                    String expectedCommandResult = String.format("[D][ ] %s (by: %s)",
+                    String expectedCommandResult = String.format("[D][ ] %s\n\t(by: %s)",
                             description, DateTimeParser.toString(DateTimeParser.toLocalDateTime(datetime)));
                     String expected = String.format(successMessage, expectedCommandResult, 1);
-                    assertEquals(expected, command.execute(new TaskList()).getResult());
+                    testCommand(commandString, expected, new TaskList());
                 }
             }
         }
@@ -35,107 +37,96 @@ class ParserTest {
     @Test
     public void deadlineCommand_invalidArgument_incorrectCommandResult() {
         String commandString = String.format("deadline %s", DESCRIPTIONS[0]);
-        Command command = Parser.parse(commandString);
         String errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        String expected = String.format(errorMsg, "deadline require the by argument.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        String expected = String.format(errorMsg, "deadline command requires the by argument.");
+        testCommand(commandString, expected, new TaskList());
 
         commandString = "deadline";
-        command = Parser.parse(commandString);
         errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        expected = String.format(errorMsg, "The description of deadline cannot be empty.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        expected = String.format(errorMsg, "deadline has invalid number of arguments.");
+        testCommand(commandString, expected, new TaskList());
 
         commandString = String.format("deadline %s /by tmr", DESCRIPTIONS[0]);
-        command = Parser.parse(commandString);
         errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        expected = String.format(errorMsg, "The force does not comprehend the date.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        String expectedErrorMsg = String.format("The force does not comprehend the date:\n%s",
+                "Text 'tmr' could not be parsed, unparsed text found at index 0");
+        expected = String.format(errorMsg, expectedErrorMsg);
+        testCommand(commandString, expected, new TaskList());
 
         commandString = "deadline /today";
-        command = Parser.parse(commandString);
         errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        expected = String.format(errorMsg, "deadline require the description argument.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        expected = String.format(errorMsg, "deadline command requires the description argument.");
+        testCommand(commandString, expected, new TaskList());
 
         commandString = "deadline sleep /today";
-        command = Parser.parse(commandString);
         errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        expected = String.format(errorMsg, "deadline require the by argument.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        expected = String.format(errorMsg, "deadline command requires the by argument.");
+        testCommand(commandString, expected, new TaskList());
     }
 
     @Test
     public void todoCommand_validArgument_correctCommandResult() {
         String successMessage = "I have added the following task into list: \n\t%s\nnow you have %d tasks in the list.";
         String commandString = "todo this work";
-        Command command = Parser.parse(commandString);
         String expectedCommandResult = "[T][ ] this work";
         String expected = String.format(successMessage, expectedCommandResult, 1);
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        testCommand(commandString, expected, new TaskList());
 
         commandString = "todo this should work too /not this";
-        command = Parser.parse(commandString);
         expectedCommandResult = "[T][ ] this should work too";
         expected = String.format(successMessage, expectedCommandResult, 1);
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        testCommand(commandString, expected, new TaskList());
     }
 
 
     @Test
     public void todoCommand_invalidArgument_incorrectCommandResult() {
         String commandString = "todo";
-        Command command = Parser.parse(commandString);
         String errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        String expected = String.format(errorMsg, "The description of todo cannot be empty.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        String expected = String.format(errorMsg, "todo has invalid number of arguments.");
+        testCommand(commandString, expected, new TaskList());
 
         commandString = "todo /this does not work";
-        command = Parser.parse(commandString);
         errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        expected = String.format(errorMsg, "todo require the description argument.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        expected = String.format(errorMsg, "todo command requires the description argument.");
+        testCommand(commandString, expected, new TaskList());
     }
 
     @Test
     public void eventCommand_invalidArgument_incorrectCommandResult() {
         String commandString = String.format("event %s", DESCRIPTIONS[0]);
-        Command command = Parser.parse(commandString);
         String errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        String expected = String.format(errorMsg, "event require the at argument.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        String expected = String.format(errorMsg, "event command requires the at argument.");
+        testCommand(commandString, expected, new TaskList());
 
         commandString = "event";
-        command = Parser.parse(commandString);
         errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        expected = String.format(errorMsg, "The description of event cannot be empty.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        expected = String.format(errorMsg, "event has invalid number of arguments.");
+        testCommand(commandString, expected, new TaskList());
 
         commandString = String.format("event %s /at Sunday noon", DESCRIPTIONS[0]);
-        command = Parser.parse(commandString);
         errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        expected = String.format(errorMsg, "The force does not comprehend the date.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        String expectedErrorMsg = String.format("The force does not comprehend the date:\n%s",
+            "Text 'Sunday noon' could not be parsed, unparsed text found at index 0");
+        expected = String.format(errorMsg, expectedErrorMsg);
+        testCommand(commandString, expected, new TaskList());
 
         commandString = "event /at Sunday noon";
-        command = Parser.parse(commandString);
         errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
-        expected = String.format(errorMsg, "event require the description argument.");
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        expected = String.format(errorMsg, "event command requires the description argument.");
+        testCommand(commandString, expected, new TaskList());
     }
 
     @Test
     public void unmarkCommand_invalidInput_incorrectCommandResult() {
         String commandString = "unmark 1";
         String expected = "The force cannot find the task.\nPlease try again :(";
-        Command command = Parser.parse(commandString);
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        testCommand(commandString, expected, new TaskList());
 
         commandString = "unmark abcdef";
         String errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
         expected = String.format(errorMsg, "The force cannot convert the value to a number.");
-        command = Parser.parse(commandString);
-        assertEquals(expected, command.execute(new TaskList()).getResult());
+        testCommand(commandString, expected, new TaskList());
     }
 
     @Test
@@ -147,8 +138,7 @@ class ParserTest {
         String expected = "Forcing it out... Success! I've removed the following task:\n\t[T][ ] %s";
         expected = String.format(expected, DESCRIPTIONS[0]);
         commandString = String.format("delete 1");
-        command = Parser.parse(commandString);
-        assertEquals(expected, command.execute(taskList).getResult());
+        testCommand(commandString, expected, taskList);
     }
 
     @Test
@@ -161,13 +151,11 @@ class ParserTest {
         commandString = String.format("mark 1");
         String expected = "Using the force... Great! I have forced this task as done.";
         expected = String.format(expected, taskList.get(0));
-        command = Parser.parse(commandString);
-        assertEquals(expected, command.execute(taskList).getResult());
+        testCommand(commandString, expected, taskList);
 
         commandString = String.format("list");
         expected = String.format("Currently, you have the following tasks:\n\t1. [T][X] %s", DESCRIPTIONS[0]);
-        command = Parser.parse(commandString);
-        assertEquals(expected, command.execute(taskList).getResult());
+        testCommand(commandString, expected, taskList);
     }
 
     @Test
@@ -181,8 +169,7 @@ class ParserTest {
         String expected = "The force is unable to find any task with the keyword...\n"
                 + "The keyword parsed is \"%s\".";
         expected = String.format(expected, DESCRIPTIONS[0]);
-        command = Parser.parse(commandString);
-        assertEquals(expected, command.execute(taskList).getResult());
+        testCommand(commandString, expected, taskList);
 
         commandString = String.format("todo %s %s", DESCRIPTIONS[0], FILLERS[0]);
         command = Parser.parse(commandString);
@@ -199,27 +186,218 @@ class ParserTest {
         commandString = String.format("find %s", DESCRIPTIONS[0]);
         expected = "The force found the following matching tasks:\n\t1. [T][ ] %s %s\n\t3. [T][ ] %s %s";
         expected = String.format(expected, DESCRIPTIONS[0], FILLERS[0], DESCRIPTIONS[0], FILLERS[1]);
-        command = Parser.parse(commandString);
-        assertEquals(expected, command.execute(taskList).getResult());
+        testCommand(commandString, expected, taskList);
 
         commandString = String.format("list");
         expected = "Currently, you have the following tasks:\n\t1. [T][ ] %s %s\n\t2. [T][ ] %s %s\n\t3. [T][ ] %s %s";
         expected = String.format(expected, DESCRIPTIONS[0], FILLERS[0],
                 DESCRIPTIONS[2], FILLERS[2], DESCRIPTIONS[0], FILLERS[1]);
-        command = Parser.parse(commandString);
-        assertEquals(expected, command.execute(taskList).getResult());
+        testCommand(commandString, expected, taskList);
     }
 
     @Test
     public void findCommand_invalidInput_incorrectCommandResult() {
-        TaskList taskList = new TaskList();
-
         String commandString = "find";
-        Command command = Parser.parse(commandString);
-        command.execute(taskList);
-
         String errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
         String expected = String.format(errorMsg, "find command requires a keyword argument.");
-        assertEquals(expected, command.execute(taskList).getResult());
+
+        testCommand(commandString, expected, new TaskList());
+    }
+
+    @Test
+    public void recurCommand_invalidInput_incorrectCommandResult() {
+        String commandString = "recur";
+        String errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
+        String expected = String.format(errorMsg, "recur has invalid number of arguments.");
+        testCommand(commandString, expected, new TaskList());
+
+        commandString = "recur event sleep /at 12/12/2022 0000";
+        errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
+        expected = String.format(errorMsg, "recur command requires the every argument.");
+        testCommand(commandString, expected, new TaskList());
+
+        commandString = "recur event sleep /at 12/12/2022 0000 /every second";
+        errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
+        errorMsg = String.format(errorMsg, "The force does not comprehend the date:\n%s");
+        expected = String.format(errorMsg, "\"second\" is not a valid argument for every.");
+        testCommand(commandString, expected, new TaskList());
+
+        commandString = "recur /every day";
+        errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
+        expected = String.format(errorMsg, "recur command requires the task argument.");
+        testCommand(commandString, expected, new TaskList());
+
+        commandString = "recur eat sleep code /every day";
+        errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
+        errorMsg = String.format(errorMsg, "recur command encountered an error:\n%s");
+        expected = String.format(errorMsg, "Command not supported.");
+        testCommand(commandString, expected, new TaskList());
+
+        commandString = "recur mark 1 /every day";
+        errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
+        errorMsg = String.format(errorMsg, "recur command encountered an error:\n%s");
+        expected = String.format(errorMsg, "Command not supported.");
+        testCommand(commandString, expected, new TaskList());
+
+        commandString = "recur todo /every day";
+        errorMsg = "Oops, the force has encountered an error:\n%s\nPlease try again :(";
+        errorMsg = String.format(errorMsg, "recur command encountered an error:\n%s");
+        expected = String.format(errorMsg, "todo command requires the description argument.");
+        testCommand(commandString, expected, new TaskList());
+    }
+
+    @Test
+    public void recurCommandAdd_validInput_correctCommandResult() {
+        LocalDateTime currentDateTimePlusOne = LocalDateTime.now().plusDays(1);
+        String dateTimeCommandString = DateTimeParser.toCommandString(currentDateTimePlusOne);
+        String dateTimeString = DateTimeParser.toString(currentDateTimePlusOne);
+        String commandString = String.format("recur event sleep /at %s /every day", dateTimeCommandString);
+        String successMessage = "I have added the following task into list: \n\t%s\nnow you have %d tasks in the list.";
+        String expectedCommandResult = String.format("[R][E][ ] sleep\n\t(at: %s) (every: day)", dateTimeString);
+        String expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, new TaskList());
+
+        LocalDateTime currentDateTimeMinusOne = LocalDateTime.now().minusDays(1);
+
+        LocalDateTime expectedDateTime = currentDateTimeMinusOne.plusWeeks(1);
+        dateTimeCommandString = DateTimeParser.toCommandString(currentDateTimeMinusOne);
+        dateTimeString = DateTimeParser.toString(expectedDateTime);
+        commandString = String.format("recur event sleep /at %s /every week", dateTimeCommandString);
+        successMessage = "I have added the following task into list: \n\t%s\nnow you have %d tasks in the list.";
+        expectedCommandResult = String.format("[R][E][ ] sleep\n\t(at: %s) (every: week)", dateTimeString);
+        expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, new TaskList());
+
+        expectedDateTime = currentDateTimeMinusOne.plusMonths(1);
+        dateTimeCommandString = DateTimeParser.toCommandString(currentDateTimeMinusOne);
+        dateTimeString = DateTimeParser.toString(expectedDateTime);
+        commandString = String.format("recur event sleep /at %s /every month", dateTimeCommandString);
+        successMessage = "I have added the following task into list: \n\t%s\nnow you have %d tasks in the list.";
+        expectedCommandResult = String.format("[R][E][ ] sleep\n\t(at: %s) (every: month)", dateTimeString);
+        expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, new TaskList());
+
+        commandString = String.format("recur todo teach /every month", dateTimeCommandString);
+        successMessage = "I have added the following task into list: \n\t%s\nnow you have %d tasks in the list.";
+        expectedCommandResult = String.format("[R][T][ ] teach (every: month)", dateTimeString);
+        expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, new TaskList());
+
+        expectedDateTime = currentDateTimeMinusOne.plusYears(1);
+        dateTimeCommandString = DateTimeParser.toCommandString(currentDateTimeMinusOne);
+        dateTimeString = DateTimeParser.toString(expectedDateTime);
+        commandString = String.format("recur deadline sleep /by %s /every year", dateTimeCommandString);
+        successMessage = "I have added the following task into list: \n\t%s\nnow you have %d tasks in the list.";
+        expectedCommandResult = String.format("[R][D][ ] sleep\n\t(by: %s) (every: year)", dateTimeString);
+        expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, new TaskList());
+    }
+
+    @Test
+    public void recurCommand_markTaskAsDone_correctCommandResult() {
+        TaskList tasklist = new TaskList();
+        LocalDateTime currentDateTime = LocalDateTime.now().plusMinutes(1);
+        String dateTimeCommandString = DateTimeParser.toCommandString(currentDateTime);
+        String dateTimeString = DateTimeParser.toString(currentDateTime);
+        String commandString = String.format("recur event sleep /at %s /every day", dateTimeCommandString);
+        Command command = Parser.parse(commandString);
+        command.execute(tasklist);
+        commandString = "mark 1";
+        command = Parser.parse(commandString);
+        command.execute(tasklist);
+
+        commandString = "list";
+        String successMessage = "Currently, you have the following tasks:\n\t%s";
+        String expectedCommandResult = String.format("1. [R][E][X] sleep\n\t(at: %s) (every: day)", dateTimeString);
+        String expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, tasklist);
+    }
+
+    @Test
+    public void recurCommand_todoLoadFromStorageMark_markRemoved() {
+        String storedData = "recur todo homework /every day /next 13/02/2022 04:01 | 1";
+        TaskList tasklist = new TaskList();
+        String[] inputs = storedData.split("\\|");
+        String commandString = inputs[0];
+        Command command = Parser.parse(commandString);
+        command.execute(tasklist);
+        tasklist.get(0).setDoneStatus(Integer.parseInt(inputs[1].strip()));
+
+        commandString = "list";
+        String successMessage = "Currently, you have the following tasks:\n\t%s";
+        String expectedCommandResult = "1. [R][T][ ] homework (every: day)";
+        String expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, tasklist);
+    }
+
+    @Test
+    public void recurCommand_todoLoadFromStorageMark_markRemained() {
+        String storedData = "recur todo homework /every day /next 13/02/2100 04:01 | 1";
+        LocalDateTime expectedDate = DateTimeParser.toLocalDateTime("13/02/2100 04:01");
+        TaskList tasklist = new TaskList();
+        String[] inputs = storedData.split("\\|");
+        String commandString = inputs[0];
+        Command command = Parser.parse(commandString);
+        command.execute(tasklist);
+        tasklist.get(0).setDoneStatus(Integer.parseInt(inputs[1].strip()));
+
+        commandString = "list";
+        String successMessage = "Currently, you have the following tasks:\n\t%s";
+        String expectedCommandResult = "1. [R][T][X] homework (every: day)";
+        String expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, tasklist);
+    }
+
+    @Test
+    public void recurCommand_eventLoadFromStorageMark_markRemained() {
+        String storedData = "recur event sleep /at 14/02/2100 12:12 /every day /next 13/02/2022 00:00 | 1";
+        LocalDateTime expectedDate = DateTimeParser.toLocalDateTime("14/02/2100 12:12");
+        Function<LocalDateTime, LocalDateTime> recurFunction = DateTimeParser.getDateTimeIncrementFunction("day");
+        while (expectedDate.isBefore(LocalDateTime.now())) {
+            expectedDate = recurFunction.apply(expectedDate);
+        }
+        String dateTimeString = DateTimeParser.toString(expectedDate);
+        TaskList tasklist = new TaskList();
+        String[] inputs = storedData.split("\\|");
+        String commandString = inputs[0];
+        Command command = Parser.parse(commandString);
+        command.execute(tasklist);
+        tasklist.get(0).setDoneStatus(Integer.parseInt(inputs[1].strip()));
+
+        commandString = "list";
+        String successMessage = "Currently, you have the following tasks:\n\t%s";
+        String expectedCommandResult = String.format("1. [R][E][X] sleep\n\t(at: %s) (every: day)", dateTimeString);
+        String expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, tasklist);
+    }
+
+    @Test
+    public void recurCommand_eventLoadFromStorageMark_markRemoved() {
+        String storedData = "recur event sleep /at 13/02/2022 12:12 /every day /next 14/02/2100 03:47 | 1";
+        LocalDateTime expectedDate = DateTimeParser.toLocalDateTime("13/02/2022 12:12");
+        Function<LocalDateTime, LocalDateTime> recurFunction = DateTimeParser.getDateTimeIncrementFunction("day");
+        while (expectedDate.isBefore(LocalDateTime.now())) {
+            expectedDate = recurFunction.apply(expectedDate);
+        }
+        String dateTimeString = DateTimeParser.toString(expectedDate);
+        TaskList tasklist = new TaskList();
+        String[] inputs = storedData.split("\\|");
+        String commandString = inputs[0];
+        Command command = Parser.parse(commandString);
+        command.execute(tasklist);
+        tasklist.get(0).setDoneStatus(Integer.parseInt(inputs[1].strip()));
+
+        commandString = "list";
+        String successMessage = "Currently, you have the following tasks:\n\t%s";
+        String expectedCommandResult = String.format("1. [R][E][ ] sleep\n\t(at: %s) (every: day)", dateTimeString);
+        String expected = String.format(successMessage, expectedCommandResult, 1);
+        testCommand(commandString, expected, tasklist);
+    }
+
+
+
+    private void testCommand(String commandString, String expectedOutput, TaskList taskList) {
+        Command command = Parser.parse(commandString);
+        assertEquals(expectedOutput, command.execute(taskList).getResult());
     }
 }


### PR DESCRIPTION
Users will now be able to add recurring tasks using the following
format:
 * Syntax: `recur <task> /every day|week|month|year`
 * Examples:
    * `recur todo code /every day`
    * `recur event team meeting /at 13/02/2022 10:30 /every week`
    * `recur deadline assignment /by 18/02/2022 23:59 /every month`

Numerous test cases have been added to ensure that recur would function
as intended.

Refactor code for storage initialization to ensure compatibility with
recurring tasks.

Update Parser to handle both Add commands and Recur commands correct ly.

Update text displayed on GUI to improve readability.